### PR TITLE
[4867][FIX] web_widget_open_tab: add missing encoding to etree.tostring

### DIFF
--- a/web_widget_open_tab/models/ir_ui_view.py
+++ b/web_widget_open_tab/models/ir_ui_view.py
@@ -34,5 +34,5 @@ class Base(models.AbstractModel):
                 tree.insert(name_field[0].getparent().index(name_field[0]) + 1, id_elem)
             else:
                 tree.insert(0, id_elem)
-        res["arch"] = etree.tostring(arch)
+        res["arch"] = etree.tostring(arch, encoding="utf-8")
         return res


### PR DESCRIPTION
[4867](https://www.quartile.co/web#model=project.task&id=4867&active_id=4867&cids=3)
I used the `utf-8` instead of `unicode` for encoding depend on this context.
https://github.com/odoo/odoo/pull/64526#issuecomment-760687743

Related: https://github.com/odoo/odoo/pull/66866