### PR TITLE
[4981][FIX] attachment_image_resize: fix not setting resize_done to true when create new attachment

### DIFF
--- a/attachment_image_resize/models/ir_attachment.py
+++ b/attachment_image_resize/models/ir_attachment.py
@@ -19,7 +19,7 @@ class IrAttachment(models.Model):
         self = self.with_context(
             resize_target_model=values.get("res_model") or self.res_model
         )
-        self.resize_done = True
+        values["resize_done"] = True
         return super()._postprocess_contents(values)
 
     @api.model


### PR DESCRIPTION
[4981](https://www.quartile.co/web?db=qrtl&token=z9OpY14OSBGGYn2qv0Ha#id=4981&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)
Only the previous logic is not covered to set the resize_done to True since there is still no record at the time of image processing during creation.
